### PR TITLE
Added cv_type_checking context var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ packages = [{ include = "runtype" }]
 [tool.poetry.dependencies]
 python = "^3.6"
 dataclasses = {version = "*", python = "~3.6"}
+contextvars = {version = "*", python = "~3.6"}
 
 [tool.poetry.dev-dependencies]
 typing_extensions = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,10 @@ typing_extensions = "*"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+# addopts = "-ra -q"
+testpaths = [
+    "tests",
+]

--- a/runtype/__init__.py
+++ b/runtype/__init__.py
@@ -1,6 +1,6 @@
 from .dataclass import dataclass
 from .dispatch import DispatchError, MultiDispatch
-from .validation import PythonTyping, TypeSystem, TypeMismatchError, assert_isa, isa, issubclass, validate_func, is_subtype
+from .validation import PythonTyping, TypeSystem, TypeMismatchError, assert_isa, isa, issubclass, validate_func, is_subtype, cv_type_checking
 from .pytypes import Constraint, String, Int
 
 __version__ = "0.3.1"

--- a/runtype/utils.py
+++ b/runtype/utils.py
@@ -1,5 +1,7 @@
 import inspect
 import sys
+import contextvars
+from contextlib import contextmanager
 
 if sys.version_info < (3, 7):
     # python 3.6 
@@ -30,3 +32,19 @@ def get_func_signatures(typesystem, f):
 
     typesigs.append(typesig)
     return typesigs
+
+
+class ContextVar:
+    def __init__(self, default, name=''):
+        self._var = contextvars.ContextVar(name, default=default)
+
+    def get(self):
+        return self._var.get()
+
+    @contextmanager
+    def __call__(self, value):
+        token = self._var.set(value)
+        try:
+            yield
+        finally:
+            self._var.reset(token)

--- a/runtype/validation.py
+++ b/runtype/validation.py
@@ -4,16 +4,21 @@ from typing import Any, Dict, List, Tuple, Set, FrozenSet, Callable
 from functools import wraps
 
 from .common import CHECK_TYPES
-from .utils import get_func_signatures
+from .utils import get_func_signatures, ContextVar
 from .pytypes import TypeMismatchError, type_caster
 from .typesystem import TypeSystem
 
+# cv_type_checking allows the user to define different behaviors for their objects
+# while they are being type-checked.
+# This is especially useful if they overrode __hash__ or __eq__ in nonconventional ways.
+cv_type_checking: ContextVar = ContextVar(False, name='type_checking')
 
 def ensure_isa(obj, t, sampler=None):
     """Ensure 'obj' is of type 't'. Otherwise, throws a TypeError
     """
-    t = type_caster.to_canon(t)
-    t.validate_instance(obj, sampler)
+    with cv_type_checking(True):
+        t = type_caster.to_canon(t)
+        t.validate_instance(obj, sampler)
 
 
 def is_subtype(t1, t2):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -109,21 +109,21 @@ class TestTypes(TestCase):
 
 
     def test_typesystem(self):
-    	t = TypeSystem()
-    	o = object()
-    	assert t.canonize_type(o) is o
+        t = TypeSystem()
+        o = object()
+        assert t.canonize_type(o) is o
 
-    	class IntOrder(TypeSystem):
-    		def issubclass(self, a, b):
-    			return a <= b 
+        class IntOrder(TypeSystem):
+            def issubclass(self, a, b):
+                return a <= b 
 
-    		def get_type(self, a):
-    			return a
+            def get_type(self, a):
+                return a
 
-    	i = IntOrder()
-    	assert i.isinstance(3, 3)
-    	assert i.isinstance(3, 4)
-    	assert not i.isinstance(4, 3)
+        i = IntOrder()
+        assert i.isinstance(3, 3)
+        assert i.isinstance(3, 4)
+        assert not i.isinstance(4, 3)
 
     def test_pytypes(self):
         assert Tuple <= Tuple


### PR DESCRIPTION
cv_type_checking allows the user to define different behaviors for their objects while they are being type-checked.
This is especially useful if they overrode __hash__ or __eq__ in nonconventional ways, when checked against Literals.